### PR TITLE
Update to Cargo 1.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
   </repositories>
 
   <properties>
-    <cargo.version>1.0.6</cargo.version>
+    <cargo.version>1.2.3</cargo.version>
   </properties>
 
     <pluginRepositories>

--- a/src/main/java/hudson/plugins/deploy/glassfish/GlassFish3xAdapter.java
+++ b/src/main/java/hudson/plugins/deploy/glassfish/GlassFish3xAdapter.java
@@ -2,7 +2,7 @@ package hudson.plugins.deploy.glassfish;
 
 import hudson.Extension;
 import hudson.plugins.deploy.ContainerAdapterDescriptor;
-import org.codehaus.cargo.container.glassfish.GlassFishStandaloneLocalConfiguration;
+import org.codehaus.cargo.container.glassfish.GlassFish3xStandaloneLocalConfiguration;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -24,7 +24,7 @@ public class GlassFish3xAdapter extends GlassFishAdapter {
     @DataBoundConstructor
     public GlassFish3xAdapter(String home, String password, String userName, Integer adminPort, String hostname) {
         super(home, password, userName, adminPort, hostname);
-        GlassFishStandaloneLocalConfiguration conf;
+        GlassFish3xStandaloneLocalConfiguration conf;
     }
 
     /**

--- a/src/main/java/hudson/plugins/deploy/tomcat/Tomcat7xAdapter.java
+++ b/src/main/java/hudson/plugins/deploy/tomcat/Tomcat7xAdapter.java
@@ -2,7 +2,7 @@ package hudson.plugins.deploy.tomcat;
 
 import hudson.Extension;
 import hudson.plugins.deploy.ContainerAdapterDescriptor;
-import org.codehaus.cargo.container.tomcat.TomcatPropertySet;
+import org.codehaus.cargo.container.property.RemotePropertySet;
 import org.codehaus.cargo.container.configuration.Configuration;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -32,7 +32,7 @@ public class Tomcat7xAdapter extends TomcatAdapter {
         super.configure(config);
         try {
             URL _url = new URL(url + "/manager/text");
-            config.setProperty(TomcatPropertySet.MANAGER_URL,_url.toExternalForm());
+            config.setProperty(RemotePropertySet.URI,_url.toExternalForm());
         } catch (MalformedURLException e) {
             throw new AssertionError(e);
         }

--- a/src/main/java/hudson/plugins/deploy/tomcat/TomcatAdapter.java
+++ b/src/main/java/hudson/plugins/deploy/tomcat/TomcatAdapter.java
@@ -1,9 +1,9 @@
 package hudson.plugins.deploy.tomcat;
 
 import hudson.plugins.deploy.PasswordProtectedAdapterCargo;
+import org.codehaus.cargo.container.property.RemotePropertySet;
 import org.codehaus.cargo.container.configuration.Configuration;
 import org.codehaus.cargo.container.deployable.WAR;
-import org.codehaus.cargo.container.tomcat.TomcatPropertySet;
 import org.codehaus.cargo.container.tomcat.TomcatWAR;
 
 import java.io.File;
@@ -30,7 +30,7 @@ public abstract class TomcatAdapter extends PasswordProtectedAdapterCargo {
         super.configure(config);
         try {
             URL _url = new URL(url + "/manager");
-            config.setProperty(TomcatPropertySet.MANAGER_URL,_url.toExternalForm());
+            config.setProperty(RemotePropertySet.URI,_url.toExternalForm());
         } catch (MalformedURLException e) {
             throw new AssertionError(e);
         }


### PR DESCRIPTION
I updated Cargo to version 1.2.3 because I want to use Tomcat 7 parallel deployment feature.

See Jira issue

https://issues.jenkins-ci.org/browse/JENKINS-13855

Some other issues could probably also be closed by this update e.g.

https://issues.jenkins-ci.org/browse/JENKINS-9537

but I tested only for issue 13855 so far.

This is my first pull request, so please be lenient with me. ;-)
