### PR TITLE
Extended functionality to allow multiple attempts to deploy a WAR/EAR.

### DIFF
--- a/src/main/java/hudson/plugins/deploy/ContainerAdapter.java
+++ b/src/main/java/hudson/plugins/deploy/ContainerAdapter.java
@@ -27,7 +27,7 @@ public abstract class ContainerAdapter implements Describable<ContainerAdapter>,
      *
      * If failed, return false.
      */
-    public abstract boolean redeploy(FilePath war, String aContextPath, AbstractBuild<?,?> build, Launcher launcher, final BuildListener listener) throws IOException, InterruptedException;
+    public abstract boolean redeploy(FilePath war, String aContextPath, int attempts, AbstractBuild<?,?> build, Launcher launcher, final BuildListener listener) throws IOException, InterruptedException;
 
     public ContainerAdapterDescriptor getDescriptor() {
         return (ContainerAdapterDescriptor)Hudson.getInstance().getDescriptor(getClass());

--- a/src/main/resources/hudson/plugins/deploy/DeployPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/deploy/DeployPublisher/config.jelly
@@ -15,4 +15,8 @@
     <f:checkbox />
   </f:entry>
 
+  <f:entry title="${%Number of attempts}" field="attempts">
+    <f:textbox default="1" />
+  </f:entry>
+
 </j:jelly>

--- a/src/test/java/hudson/plugins/deploy/glassfish/GlassFish3xAdapterTest.java
+++ b/src/test/java/hudson/plugins/deploy/glassfish/GlassFish3xAdapterTest.java
@@ -77,13 +77,13 @@ public class GlassFish3xAdapterTest {
     //@Test
     public void testDeploy() throws IOException, InterruptedException {
         
-        adapter.redeploy(new FilePath(new File("src/test/simple.war")), "contextPath", null, null, new StreamBuildListener(System.out));
+        adapter.redeploy(new FilePath(new File("src/test/simple.war")), "contextPath", 1, null, null, new StreamBuildListener(System.out));
     }
     
     //@Test
     public void testRemoteDeploy() throws IOException, InterruptedException {
        
 
-        remoteAdapter.redeploy(new FilePath(new File("src/test/simple.war")), "contextPath", null, null, new StreamBuildListener(System.out));
+        remoteAdapter.redeploy(new FilePath(new File("src/test/simple.war")), "contextPath", 1, null, null, new StreamBuildListener(System.out));
     }
 }


### PR DESCRIPTION
Hi,

I created an enhancement for the Deploy plugin to enable multiple attempts to deploy a WAR/EAR. This is configurable per Job in as part of the Post Build action.

This is useful for environments where the Container stops and starts, either on purpose or unexpectedly. For us, its useful for web-apps the leak memory on redeployment and end up causing Tomcat OutOfMemory errors, which cause Tomcat to restart automatically. 

Without it, we in a horizontally scaled environment, we can end up with different version of code between instances, when, for example, the deploy to instance-A works, and then the deploy attempt to instance-B fails.

  --joe