### PR TITLE
Use BuildWatcher in RemoteCallableTest

### DIFF
--- a/src/test/java/hudson/plugins/deploy/RemoteCallableTest.java
+++ b/src/test/java/hudson/plugins/deploy/RemoteCallableTest.java
@@ -36,6 +36,8 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.ArrayList;
+import org.junit.ClassRule;
+import org.jvnet.hudson.test.BuildWatcher;
 
 /**
  * Tests that deployment can be called from a remote agent.
@@ -44,6 +46,8 @@ import java.util.ArrayList;
  */
 public class RemoteCallableTest {
 
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule
     public JenkinsRule j = new JenkinsRule();
 


### PR DESCRIPTION
For me on Linux the build ends with

```
INFO: test0 #2 main build action completed: SUCCESS
[test0 #2] [DeployPublisher][INFO] Attempting to deploy 1 war file(s)
[test0 #2] [DeployPublisher][INFO] Deploying /tmp/jenkinsTests.tmp/jenkins…test/workspace/test0/simple….war to container Tomcat 8.x Remote with context 
[test0 #2] ERROR: Build step failed with exception
[test0 #2] org.codehaus.cargo.container.ContainerException: Failed to redeploy [/tmp/jenkinsTests.tmp/jenkins…test/workspace/test0/simple….war]
[test0 #2] 	at org.codehaus.cargo.container.tomcat.internal.AbstractTomcatManagerDeployer.redeploy(AbstractTomcatManagerDeployer.java:188)
[test0 #2] 	at hudson.plugins.deploy.CargoContainerAdapter.deploy(CargoContainerAdapter.java:81)
[test0 #2] 	at hudson.plugins.deploy.CargoContainerAdapter$DeployCallable.invoke(CargoContainerAdapter.java:167)
[test0 #2] 	at hudson.plugins.deploy.CargoContainerAdapter$DeployCallable.invoke(CargoContainerAdapter.java:136)
[test0 #2] 	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:2719)
[test0 #2] 	at hudson.remoting.UserRequest.perform(UserRequest.java:120)
[test0 #2] 	at hudson.remoting.UserRequest.perform(UserRequest.java:48)
[test0 #2] 	at hudson.remoting.Request$2.run(Request.java:326)
[test0 #2] 	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
[test0 #2] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[test0 #2] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[test0 #2] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[test0 #2] 	at java.lang.Thread.run(Thread.java:748)
[test0 #2] 	at ......remote call to slave0(Native Method)
[test0 #2] 	at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1416)
[test0 #2] 	at hudson.remoting.UserResponse.retrieve(UserRequest.java:220)
[test0 #2] 	at hudson.remoting.Channel.call(Channel.java:781)
[test0 #2] 	at hudson.FilePath.act(FilePath.java:979)
[test0 #2] 	at hudson.FilePath.act(FilePath.java:968)
[test0 #2] 	at hudson.plugins.deploy.CargoContainerAdapter.redeployFile(CargoContainerAdapter.java:133)
[test0 #2] 	at hudson.plugins.deploy.PasswordProtectedAdapterCargo.redeployFile(PasswordProtectedAdapterCargo.java:95)
[test0 #2] 	at hudson.plugins.deploy.DeployPublisher.perform(DeployPublisher.java:113)
[test0 #2] 	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:78)
[test0 #2] 	at hudson.tasks.BuildStepMonitor$3.perform(BuildStepMonitor.java:45)
[test0 #2] 	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:782)
[test0 #2] 	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:723)
[test0 #2] 	at hudson.model.Build$BuildExecution.post2(Build.java:185)
[test0 #2] 	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:668)
[test0 #2] 	at hudson.model.Run.execute(Run.java:1763)
[test0 #2] 	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
[test0 #2] 	at hudson.model.ResourceController.execute(ResourceController.java:98)
[test0 #2] 	at hudson.model.Executor.run(Executor.java:410)
[test0 #2] Caused by: java.io.FileNotFoundException: http://example.com/manager/text/list
[test0 #2] 	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1890)
[test0 #2] 	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1492)
[test0 #2] 	at org.codehaus.cargo.container.tomcat.internal.TomcatManager.invoke(TomcatManager.java:577)
[test0 #2] 	at org.codehaus.cargo.container.tomcat.internal.TomcatManager.list(TomcatManager.java:882)
[test0 #2] 	at org.codehaus.cargo.container.tomcat.internal.TomcatManager.getStatus(TomcatManager.java:895)
[test0 #2] 	at org.codehaus.cargo.container.tomcat.internal.AbstractTomcatManagerDeployer.redeploy(AbstractTomcatManagerDeployer.java:169)
[test0 #2] 	at hudson.plugins.deploy.CargoContainerAdapter.deploy(CargoContainerAdapter.java:81)
[test0 #2] 	at hudson.plugins.deploy.CargoContainerAdapter$DeployCallable.invoke(CargoContainerAdapter.java:167)
[test0 #2] 	at hudson.plugins.deploy.CargoContainerAdapter$DeployCallable.invoke(CargoContainerAdapter.java:136)
[test0 #2] 	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:2719)
[test0 #2] 	at hudson.remoting.UserRequest.perform(UserRequest.java:120)
[test0 #2] 	at hudson.remoting.UserRequest.perform(UserRequest.java:48)
[test0 #2] 	at hudson.remoting.Request$2.run(Request.java:326)
[test0 #2] 	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
[test0 #2] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[test0 #2] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[test0 #2] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[test0 #2] 	at java.lang.Thread.run(Thread.java:748)
[test0 #2] java.io.FileNotFoundException: http://example.com/manager/text/list
[test0 #2] 	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1890)
[test0 #2] 	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1492)
[test0 #2] 	at org.codehaus.cargo.container.tomcat.internal.TomcatManager.invoke(TomcatManager.java:577)
[test0 #2] 	at org.codehaus.cargo.container.tomcat.internal.TomcatManager.list(TomcatManager.java:882)
[test0 #2] 	at org.codehaus.cargo.container.tomcat.internal.TomcatManager.getStatus(TomcatManager.java:895)
[test0 #2] 	at org.codehaus.cargo.container.tomcat.internal.AbstractTomcatManagerDeployer.redeploy(AbstractTomcatManagerDeployer.java:169)
[test0 #2] 	at hudson.plugins.deploy.CargoContainerAdapter.deploy(CargoContainerAdapter.java:81)
[test0 #2] 	at hudson.plugins.deploy.CargoContainerAdapter$DeployCallable.invoke(CargoContainerAdapter.java:167)
[test0 #2] 	at hudson.plugins.deploy.CargoContainerAdapter$DeployCallable.invoke(CargoContainerAdapter.java:136)
[test0 #2] 	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:2719)
[test0 #2] 	at hudson.remoting.UserRequest.perform(UserRequest.java:120)
[test0 #2] 	at hudson.remoting.UserRequest.perform(UserRequest.java:48)
[test0 #2] 	at hudson.remoting.Request$2.run(Request.java:326)
[test0 #2] 	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
[test0 #2] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[test0 #2] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[test0 #2] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[test0 #2] 	at java.lang.Thread.run(Thread.java:748)
[test0 #2] Build step 'Deploy war/ear to a container' marked build as failure
[test0 #2] Finished: FAILURE
```

Note that the test is asserting that it gets a 404 after actually making a request to example.com, a real domain with an HTTP service, which is not a good idea.