### PR TITLE
Jenkins 51440 configure alternative context for each tomcat container

### DIFF
--- a/src/main/java/hudson/plugins/deploy/tomcat/Tomcat4xAdapter.java
+++ b/src/main/java/hudson/plugins/deploy/tomcat/Tomcat4xAdapter.java
@@ -2,6 +2,8 @@ package hudson.plugins.deploy.tomcat;
 
 import hudson.Extension;
 import hudson.plugins.deploy.ContainerAdapterDescriptor;
+
+import org.codehaus.cargo.container.tomcat.Tomcat4xRemoteContainer;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -14,13 +16,13 @@ public class Tomcat4xAdapter extends TomcatAdapter {
     private static final long serialVersionUID = -3577537993151201721L;
 
     @DataBoundConstructor
-    public Tomcat4xAdapter(String url, String credentialsId) {
-        super(url, credentialsId);
+    public Tomcat4xAdapter(String url, String credentialsId, String path) {
+        super(url, credentialsId, path);
     }
 
     @Override
     public String getContainerId() {
-        return "tomcat4x";
+        return Tomcat4xRemoteContainer.ID;
     }
 
     @Symbol("tomcat4")
@@ -28,7 +30,7 @@ public class Tomcat4xAdapter extends TomcatAdapter {
     public static final class DescriptorImpl extends ContainerAdapterDescriptor {
         @Override
         public String getDisplayName() {
-            return "Tomcat 4.x";
+            return new Tomcat4xRemoteContainer(null).getName();
         }
     }
 }

--- a/src/main/java/hudson/plugins/deploy/tomcat/Tomcat5xAdapter.java
+++ b/src/main/java/hudson/plugins/deploy/tomcat/Tomcat5xAdapter.java
@@ -2,6 +2,8 @@ package hudson.plugins.deploy.tomcat;
 
 import hudson.Extension;
 import hudson.plugins.deploy.ContainerAdapterDescriptor;
+
+import org.codehaus.cargo.container.tomcat.Tomcat5xRemoteContainer;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -14,13 +16,13 @@ public class Tomcat5xAdapter extends TomcatAdapter {
     private static final long serialVersionUID = 2441615146518612287L;
 
     @DataBoundConstructor
-    public Tomcat5xAdapter(String url, String credentialsId) {
-        super(url, credentialsId);
+    public Tomcat5xAdapter(String url, String credentialsId, String path) {
+        super(url, credentialsId, path);
     }
 
     @Override
     public String getContainerId() {
-        return "tomcat5x";
+        return Tomcat5xRemoteContainer.ID;
     }
 
     @Symbol("tomcat5")
@@ -28,7 +30,7 @@ public class Tomcat5xAdapter extends TomcatAdapter {
     public static final class DescriptorImpl extends ContainerAdapterDescriptor {
         @Override
         public String getDisplayName() {
-            return "Tomcat 5.x";
+            return new Tomcat5xRemoteContainer(null).getName();
         }
     }
 }

--- a/src/main/java/hudson/plugins/deploy/tomcat/Tomcat6xAdapter.java
+++ b/src/main/java/hudson/plugins/deploy/tomcat/Tomcat6xAdapter.java
@@ -2,6 +2,8 @@ package hudson.plugins.deploy.tomcat;
 
 import hudson.Extension;
 import hudson.plugins.deploy.ContainerAdapterDescriptor;
+
+import org.codehaus.cargo.container.tomcat.Tomcat6xRemoteContainer;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -14,13 +16,13 @@ public class Tomcat6xAdapter extends TomcatAdapter {
     private static final long serialVersionUID = 1558737368614036333L;
 
     @DataBoundConstructor
-    public Tomcat6xAdapter(String url, String credentialsId) {
-        super(url, credentialsId);
+    public Tomcat6xAdapter(String url, String credentialsId, String path) {
+        super(url, credentialsId, path);
     }
 
     @Override
     public String getContainerId() {
-        return "tomcat6x";
+        return Tomcat6xRemoteContainer.ID;
     }
 
     @Symbol("tomcat6")
@@ -28,7 +30,7 @@ public class Tomcat6xAdapter extends TomcatAdapter {
     public static final class DescriptorImpl extends ContainerAdapterDescriptor {
         @Override
         public String getDisplayName() {
-            return "Tomcat 6.x";
+            return new Tomcat6xRemoteContainer(null).getName();
         }
     }
 }

--- a/src/main/java/hudson/plugins/deploy/tomcat/Tomcat7xAdapter.java
+++ b/src/main/java/hudson/plugins/deploy/tomcat/Tomcat7xAdapter.java
@@ -3,6 +3,7 @@ package hudson.plugins.deploy.tomcat;
 import hudson.Extension;
 import hudson.plugins.deploy.ContainerAdapterDescriptor;
 
+import org.codehaus.cargo.container.tomcat.Tomcat7xRemoteContainer;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -14,22 +15,21 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class Tomcat7xAdapter extends TomcatAdapter {
     private static final long serialVersionUID = -7404114022873678861L;
 
-    private static final String PATH = "/manager/text";
-
     /**
      * Tomcat 7 support
      *
      * @param url Tomcat server location (for example: http://localhost:8080)
      * @param credentialsId the tomcat user credentials
+     * @param path an alternative manager context path
      */
     @DataBoundConstructor
-    public Tomcat7xAdapter(String url, String credentialsId) {
-        super(url, credentialsId, PATH);
+    public Tomcat7xAdapter(String url, String credentialsId, String path) {
+        super(url, credentialsId, path);
     }
 
     @Override
     public String getContainerId() {
-        return "tomcat7x";
+        return Tomcat7xRemoteContainer.ID;
     }
 
     @Symbol("tomcat7")
@@ -37,7 +37,7 @@ public class Tomcat7xAdapter extends TomcatAdapter {
     public static final class DescriptorImpl extends ContainerAdapterDescriptor {
         @Override
         public String getDisplayName() {
-            return "Tomcat 7.x";
+            return new Tomcat7xRemoteContainer(null).getName();
         }
     }
 }

--- a/src/main/java/hudson/plugins/deploy/tomcat/Tomcat8xAdapter.java
+++ b/src/main/java/hudson/plugins/deploy/tomcat/Tomcat8xAdapter.java
@@ -3,6 +3,7 @@ package hudson.plugins.deploy.tomcat;
 import hudson.Extension;
 import hudson.plugins.deploy.ContainerAdapterDescriptor;
 
+import org.codehaus.cargo.container.tomcat.Tomcat8xRemoteContainer;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -14,22 +15,21 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class Tomcat8xAdapter extends TomcatAdapter {
     private static final long serialVersionUID = -998875391401118618L;
 
-    private static final String PATH = "/manager/text";
-
     /**
      * Tomcat 8 support
      *
      * @param url Tomcat server location (for example: http://localhost:8080)
      * @param credentialsId tomcat manager username password credentials
+     * @param path an alternative manager context path
      */
     @DataBoundConstructor
-    public Tomcat8xAdapter(String url, String credentialsId) {
-        super(url, credentialsId, PATH);
+    public Tomcat8xAdapter(String url, String credentialsId, String path) {
+        super(url, credentialsId, path);
     }
 
     @Override
     public String getContainerId() {
-        return "tomcat8x";
+        return Tomcat8xRemoteContainer.ID;
     }
 
     @Symbol("tomcat8")
@@ -37,7 +37,7 @@ public class Tomcat8xAdapter extends TomcatAdapter {
     public static final class DescriptorImpl extends ContainerAdapterDescriptor {
         @Override
         public String getDisplayName() {
-            return "Tomcat 8.x";
+            return new Tomcat8xRemoteContainer(null).getName();
         }
     }
 }

--- a/src/main/java/hudson/plugins/deploy/tomcat/Tomcat9xAdapter.java
+++ b/src/main/java/hudson/plugins/deploy/tomcat/Tomcat9xAdapter.java
@@ -3,6 +3,7 @@ package hudson.plugins.deploy.tomcat;
 import hudson.Extension;
 import hudson.plugins.deploy.ContainerAdapterDescriptor;
 
+import org.codehaus.cargo.container.tomcat.Tomcat9xRemoteContainer;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -14,22 +15,21 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class Tomcat9xAdapter extends TomcatAdapter {
     private static final long serialVersionUID = -7479041536985095270L;
 
-    private static final String PATH = "/manager/text";
-
     /**
      * Tomcat 9 support
      *
      * @param url Tomcat server location (for example: http://localhost:8080)
      * @param credentialsId tomcat manager username password credentials
+     * @param path an alternative manager context path
      */
     @DataBoundConstructor
-    public Tomcat9xAdapter(String url, String credentialsId) {
-        super(url, credentialsId, PATH);
+    public Tomcat9xAdapter(String url, String credentialsId, String path) {
+        super(url, credentialsId, path);
     }
 
     @Override
     public String getContainerId() {
-        return "tomcat9x";
+        return Tomcat9xRemoteContainer.ID;
     }
 
     @Symbol("tomcat9")
@@ -37,7 +37,7 @@ public class Tomcat9xAdapter extends TomcatAdapter {
     public static final class DescriptorImpl extends ContainerAdapterDescriptor {
         @Override
         public String getDisplayName() {
-            return "Tomcat 9.x";
+            return new Tomcat9xRemoteContainer(null).getName();
         }
     }
 }

--- a/src/main/java/hudson/plugins/deploy/tomcat/TomcatAdapter.java
+++ b/src/main/java/hudson/plugins/deploy/tomcat/TomcatAdapter.java
@@ -1,17 +1,18 @@
 package hudson.plugins.deploy.tomcat;
 
-import hudson.EnvVars;
-import hudson.plugins.deploy.PasswordProtectedAdapterCargo;
-import hudson.util.VariableResolver;
-
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import org.apache.commons.lang.StringUtils;
 import org.codehaus.cargo.container.configuration.Configuration;
 import org.codehaus.cargo.container.deployable.WAR;
 import org.codehaus.cargo.container.property.RemotePropertySet;
 import org.codehaus.cargo.container.tomcat.TomcatWAR;
+
+import hudson.EnvVars;
+import hudson.plugins.deploy.PasswordProtectedAdapterCargo;
+import hudson.util.VariableResolver;
 
 /**
  * Base class for Tomcat adapters.
@@ -25,11 +26,12 @@ public abstract class TomcatAdapter extends PasswordProtectedAdapterCargo {
      * Top URL of Tomcat.
      */
     public final String url;
-    private String path = "/manager";
+    private final String path;
 
     public TomcatAdapter(String url, String credentialsId) {
         super(credentialsId);
         this.url = url;
+        this.path = null;
     }
 
     public TomcatAdapter(String url, String credentialsId, String path) {
@@ -43,12 +45,19 @@ public abstract class TomcatAdapter extends PasswordProtectedAdapterCargo {
         return url;
     }
 
+    public String getPath() {
+        return path;
+    }
+
     @Override
     public void configure(Configuration config, EnvVars envVars, VariableResolver<String> resolver) {
         super.configure(config, envVars, resolver);
         try {
-            URL _url = new URL(expandVariable(envVars, resolver, this.url) + path);
-            config.setProperty(RemotePropertySet.URI, _url.toExternalForm());
+            // overwrite remote URI if alternative manager context path is specified
+            if (StringUtils.isNotBlank(this.path)) {
+                URL _url = new URL(expandVariable(envVars, resolver, this.url) + expandVariable(envVars, resolver, this.path));
+                config.setProperty(RemotePropertySet.URI, _url.toExternalForm());
+            }
         } catch (MalformedURLException e) {
             throw new AssertionError(e);
         }

--- a/src/main/resources/hudson/plugins/deploy/tomcat/TomcatAdapter/config.jelly
+++ b/src/main/resources/hudson/plugins/deploy/tomcat/TomcatAdapter/config.jelly
@@ -7,4 +7,9 @@
   <f:entry title="Tomcat URL" field="url">
     <f:textbox />
   </f:entry>
+  <f:advanced>
+    <f:entry title="Manager context path" field="path">
+        <f:textbox />
+    </f:entry>
+  </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/deploy/tomcat/TomcatAdapter/help-path.html
+++ b/src/main/resources/hudson/plugins/deploy/tomcat/TomcatAdapter/help-path.html
@@ -1,0 +1,3 @@
+<div>
+    The alternative manager context path. Overwrites the default value '/manager' for Tomcat 4-6 or '/manager/text' for Tomcat 7+.
+</div>

--- a/src/main/resources/hudson/plugins/deploy/tomcat/TomcatAdapter/help-url.html
+++ b/src/main/resources/hudson/plugins/deploy/tomcat/TomcatAdapter/help-url.html
@@ -1,0 +1,3 @@
+<div>
+    The Tomcat base URL to use for deployment (e.g. https://tomcat.my-company.com:8443).
+</div>

--- a/src/test/java/hudson/plugins/deploy/PipelineSyntaxTest.java
+++ b/src/test/java/hudson/plugins/deploy/PipelineSyntaxTest.java
@@ -126,7 +126,7 @@ public class PipelineSyntaxTest {
         j.getInstance().createProject(WorkflowJob.class, "SnippetTest");
         SnippetizerTester t = new SnippetizerTester(j);
 
-        ContainerAdapter tc = new Tomcat8xAdapter("http://example.com", "test-id");
+        ContainerAdapter tc = new Tomcat8xAdapter("http://example.com", "test-id", null);
         DeployPublisher dp = new DeployPublisher(Collections.singletonList(tc), "app.war");
 
         t.assertRoundTrip(new CoreStep(dp), "deploy adapters: [tomcat8(credentialsId: 'test-id', url: 'http://example.com')], war: 'app.war'");
@@ -137,11 +137,22 @@ public class PipelineSyntaxTest {
         WorkflowJob p = j.getInstance().createProject(WorkflowJob.class, "SnippetTest");
         SnippetizerTester t = new SnippetizerTester(j);
 
-        ContainerAdapter tc = new Tomcat8xAdapter("http://example.com", "test-id");
+        ContainerAdapter tc = new Tomcat8xAdapter("http://example.com", "test-id", null);
         DeployPublisher dp = new DeployPublisher(Collections.singletonList(tc), "app.war");
         dp.setOnFailure(!j.jenkins.getDescriptorByType(DeployPublisher.DescriptorImpl.class).defaultOnFailure(p));
         dp.setContextPath("my-app");
 
         t.assertRoundTrip(new CoreStep(dp), "deploy adapters: [tomcat8(credentialsId: 'test-id', url: 'http://example.com')], contextPath: 'my-app', onFailure: false, war: 'app.war'");
+    }
+
+    @Test
+    public void testSnippetizerPath() throws Exception {
+        j.getInstance().createProject(WorkflowJob.class, "SnippetTest");
+        SnippetizerTester t = new SnippetizerTester(j);
+
+        ContainerAdapter tc = new Tomcat8xAdapter("http://example.com", "test-id", "/foo-manager/text");
+        DeployPublisher dp = new DeployPublisher(Collections.singletonList(tc), "app.war");
+
+        t.assertRoundTrip(new CoreStep(dp), "deploy adapters: [tomcat8(credentialsId: 'test-id', path: '/foo-manager/text', url: 'http://example.com')], war: 'app.war'");
     }
 }

--- a/src/test/java/hudson/plugins/deploy/RemoteCallableTest.java
+++ b/src/test/java/hudson/plugins/deploy/RemoteCallableTest.java
@@ -73,7 +73,7 @@ public class RemoteCallableTest {
                 new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "test-id", "", "user", "pass"));
 
         ArrayList<ContainerAdapter> adapters = new ArrayList<ContainerAdapter>();
-        adapters.add(new Tomcat8xAdapter(j.getURL().toExternalForm(), "test-id"));
+        adapters.add(new Tomcat8xAdapter(j.getURL().toExternalForm(), "test-id", "/manager/text"));
         project.getPublishersList().add(new DeployPublisher(adapters, war.getName()));
 
         Run<?, ?> run = project.scheduleBuild2(0).get();

--- a/src/test/java/hudson/plugins/deploy/tomcat/Tomcat7xAdapterTest.java
+++ b/src/test/java/hudson/plugins/deploy/tomcat/Tomcat7xAdapterTest.java
@@ -35,7 +35,8 @@ public class Tomcat7xAdapterTest {
 
     private Tomcat7xAdapter adapter;
     private static final String url = "http://localhost:8080";
-    private static final String configuredUrl = "http://localhost:8080/manager/text";
+    private static final String managerContextPath = "/foo-manager/text";
+    private static final String configuredUrl = url + managerContextPath;
     private static final String urlVariable = "URL";
     private static final String username = "usernm";
     private static final String usernameVariable = "user";
@@ -50,7 +51,7 @@ public class Tomcat7xAdapterTest {
         UsernamePasswordCredentialsImpl c = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "test", "sample", username, password);
         CredentialsProvider.lookupStores(jenkinsRule.jenkins).iterator().next().addCredentials(Domain.global(), c);
 
-        adapter = new  Tomcat7xAdapter(url, c.getId());
+        adapter = new Tomcat7xAdapter(url, c.getId(), null);
         adapter.loadCredentials(/* temp project to avoid npe */ jenkinsRule.createFreeStyleProject());
     }
 
@@ -85,7 +86,7 @@ public class Tomcat7xAdapterTest {
                 "", getVariable(usernameVariable), password);
         CredentialsProvider.lookupStores(jenkinsRule.jenkins).iterator().next().addCredentials(Domain.global(), c);
 
-        adapter = new Tomcat7xAdapter(getVariable(urlVariable), c.getId());
+        adapter = new Tomcat7xAdapter(getVariable(urlVariable), c.getId(), managerContextPath);
         Configuration config = new DefaultConfigurationFactory().createConfiguration(adapter.getContainerId(), ContainerType.REMOTE, ConfigurationType.RUNTIME);
         adapter.migrateCredentials(Collections.<StandardUsernamePasswordCredentials>emptyList());
         adapter.loadCredentials(project);


### PR DESCRIPTION
Fixes problems introduced with manager context path variable in last version. We now rely on Cargo to construct the right deploy URL except if configuring an alternative manager context path.